### PR TITLE
Implement global loader with interceptor

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,3 +2,4 @@
 <div class="main-content">
   <router-outlet></router-outlet>
 </div>
+<app-loader></app-loader>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,6 +24,9 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrModule } from 'ngx-toastr';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MonitorComponent } from './monitor/monitor.component';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { LoaderComponent } from './loader/loader.component';
+import { LoaderInterceptor } from './interceptors/loader.interceptor';
 
 // theme-toggle\theme-toggle.component
 
@@ -40,7 +43,8 @@ import { MonitorComponent } from './monitor/monitor.component';
     HeaderComponent,
     ThemeToggleComponent,
     DashboardComponent,
-    MonitorComponent
+    MonitorComponent,
+    LoaderComponent
   ],
   imports: [
     BrowserModule,
@@ -56,6 +60,11 @@ import { MonitorComponent } from './monitor/monitor.component';
   providers: [
     provideClientHydration(),
     DatePipe, // Add DatePipe to providers
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: LoaderInterceptor,
+      multi: true
+    }
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/interceptors/loader.interceptor.ts
+++ b/src/app/interceptors/loader.interceptor.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse, HttpErrorResponse } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { LoaderService } from '../services/loader.service';
+
+@Injectable()
+export class LoaderInterceptor implements HttpInterceptor {
+  constructor(private loaderService: LoaderService) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    this.loaderService.show();
+    return next.handle(req).pipe(
+      finalize(() => this.loaderService.hide())
+    );
+  }
+}

--- a/src/app/loader/loader.component.css
+++ b/src/app/loader/loader.component.css
@@ -1,0 +1,17 @@
+.loader-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1050; /* higher than bootstrap modal backdrop */
+}
+
+.spinner-border {
+  width: 3rem;
+  height: 3rem;
+}

--- a/src/app/loader/loader.component.html
+++ b/src/app/loader/loader.component.html
@@ -1,0 +1,5 @@
+<div class="loader-overlay" *ngIf="loaderService.isLoading$ | async">
+  <div class="spinner-border text-primary" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+</div>

--- a/src/app/loader/loader.component.ts
+++ b/src/app/loader/loader.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { LoaderService } from '../services/loader.service';
+
+@Component({
+  selector: 'app-loader',
+  templateUrl: './loader.component.html',
+  styleUrls: ['./loader.component.css']
+})
+export class LoaderComponent {
+  constructor(public loaderService: LoaderService) {}
+}

--- a/src/app/services/loader.service.ts
+++ b/src/app/services/loader.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LoaderService {
+  private loadingRequests = 0;
+  private _isLoading$ = new BehaviorSubject<boolean>(false);
+  readonly isLoading$ = this._isLoading$.asObservable();
+
+  show(): void {
+    this.loadingRequests++;
+    if (this.loadingRequests === 1) {
+      this._isLoading$.next(true);
+    }
+  }
+
+  hide(): void {
+    if (this.loadingRequests > 0) {
+      this.loadingRequests--;
+    }
+    if (this.loadingRequests === 0) {
+      this._isLoading$.next(false);
+    }
+  }
+
+  reset(): void {
+    this.loadingRequests = 0;
+    this._isLoading$.next(false);
+  }
+}


### PR DESCRIPTION
## Summary
- add LoaderService to manage loading state
- create LoaderComponent that displays a bootstrap spinner
- add LoaderInterceptor to automatically show/hide the loader during HTTP calls
- register interceptor and component in `AppModule`
- include loader overlay in the app root template

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*