### PR TITLE
Fix toastr position globally

### DIFF
--- a/src/app/add-record/add-record.component.ts
+++ b/src/app/add-record/add-record.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { ApiService } from '../api.service';
 import { Router } from '@angular/router';
+import { ToastrService } from 'ngx-toastr';
 
 @Component({
   selector: 'app-add-record',
@@ -12,7 +13,7 @@ export class AddRecordComponent {
   successMessage: string | null = null;
   errorMessage: string | null = null;
 
-  constructor(private apiService: ApiService, private router: Router) {}
+  constructor(private apiService: ApiService, private router: Router, private toastr: ToastrService) {}
 
   // File selection logic
   onFileSelected(event: any): void {
@@ -25,6 +26,7 @@ export class AddRecordComponent {
   submitRecord(): void {
     if (!this.selectedFile) {
       this.errorMessage = 'Please select a file before submitting.';
+      this.toastr.error('Failed to create item.', 'Error');
       return;
     }
 
@@ -32,15 +34,17 @@ export class AddRecordComponent {
     formData.append('audio', this.selectedFile);
 
     this.apiService.addAudioRecord(formData).subscribe({
-      next: (response) => {
+      next: () => {
         this.successMessage = 'File uploaded successfully!';
         this.errorMessage = null;
+        this.toastr.success('Item created successfully!', 'Success');
         setTimeout(() => this.router.navigate(['/process-audio']), 2000); // Redirect after 2 seconds
       },
       error: (err) => {
         console.error('Error uploading file:', err);
         this.errorMessage = 'Failed to upload the file. Please try again.';
         this.successMessage = null;
+        this.toastr.error('Failed to create item.', 'Error');
       },
     });
   }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -54,7 +54,9 @@ import { LoaderInterceptor } from './interceptors/loader.interceptor';
     ReactiveFormsModule,
     NgbModule,
     BrowserAnimationsModule,
-    ToastrModule.forRoot(),
+    ToastrModule.forRoot({
+      positionClass: 'toast-top-right'
+    }),
     CommonModule, // Add CommonModule
   ],
   providers: [
@@ -64,7 +66,7 @@ import { LoaderInterceptor } from './interceptors/loader.interceptor';
       provide: HTTP_INTERCEPTORS,
       useClass: LoaderInterceptor,
       multi: true
-    }
+    },
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -121,10 +121,11 @@ export class DashboardComponent {
         this.kpis[1].count = data.active_sessions;
         this.kpis[2].count = data.total_sops;
         this.kpis[3].count = data.pending_reviews;
-
+        this.toasterService.success('Data loaded successfully!', 'Success');
       },
       error: (err) => {
         console.error(err);
+        this.toasterService.error('Failed to load data.', 'Error');
       },
     })
   }
@@ -134,9 +135,11 @@ export class DashboardComponent {
     this.apiService.getUsers().subscribe({
       next: (data: any) => {
         this.users = data.results;
+        this.toasterService.success('Data loaded successfully!', 'Success');
       },
       error: (err) => {
         console.error(err);
+        this.toasterService.error('Failed to load data.', 'Error');
       },
     })
   }
@@ -145,9 +148,11 @@ export class DashboardComponent {
     this.apiService.getSOPs().subscribe({
       next: (data: any) => {
         this.sops = data.results;
+        this.toasterService.success('Data loaded successfully!', 'Success');
       },
       error: (err) => {
         console.error(err);
+        this.toasterService.error('Failed to load data.', 'Error');
       },
     })
   }
@@ -180,10 +185,11 @@ export class DashboardComponent {
         if (result === 'Confirm') {
           this.apiService.deleteUser(userId).subscribe({
             next: (data: any) => {
-              this.toasterService.show("test");
+              this.toasterService.success('Item deleted successfully!', 'Success');
             },
             error: (err) => {
               console.error(err);
+              this.toasterService.error('Failed to delete item.', 'Error');
             },
           })
         }
@@ -200,10 +206,11 @@ export class DashboardComponent {
         if (result === 'Confirm') {
           this.apiService.deleteSOP(sopId).subscribe({
             next: (data: any) => {
-              this.toasterService.show("test");
+              this.toasterService.success('Item deleted successfully!', 'Success');
             },
             error: (err) => {
               console.error(err);
+              this.toasterService.error('Failed to delete item.', 'Error');
             },
           })
         }
@@ -214,9 +221,6 @@ export class DashboardComponent {
     );
   }
   
-  showSuccessToast() {
-    this.toasterService.success('User Added Successfully.','success',{ positionClass: 'toast-center-center'});
-  }
 
   onSubmit(modal: any): void {
     if (this.createUserForm.valid) {
@@ -228,11 +232,12 @@ export class DashboardComponent {
             this.isEditing = false;
             this.editingUserId = null;
             modal.dismiss();
-            this.showSuccessToast();
+            this.toasterService.success('Item updated successfully!', 'Success');
             this.createUserForm.reset();
           },
           error: (err) => {
             console.error(err);
+            this.toasterService.error('Failed to update item.', 'Error');
           },
         })
       } else {
@@ -242,11 +247,12 @@ export class DashboardComponent {
             this.fetchUsers();
           }
           modal.dismiss();
-          this.showSuccessToast();
+          this.toasterService.success('Item created successfully!', 'Success');
           this.createUserForm.reset();
         },
         error: (err) => {
           console.error(err);
+          this.toasterService.error('Failed to create item.', 'Error');
         },
       })
     }
@@ -288,12 +294,13 @@ export class DashboardComponent {
             this.isSOPEditing = false;
             this.editingSOPId = null;
             modal.dismiss();
-            this.showSuccessToast();
+            this.toasterService.success('Item updated successfully!', 'Success');
             this.sopForm.reset();
             this.resetSOPSteps();
           },
           error: (err) => {
             console.error(err);
+            this.toasterService.error('Failed to update item.', 'Error');
           },
         })
       } else {
@@ -306,10 +313,11 @@ export class DashboardComponent {
           this.submitted = false;
           this.sopForm.reset();
           this.resetSOPSteps();
-          this.showSuccessToast();
+          this.toasterService.success('Item created successfully!', 'Success');
         },
         error: (err) => {
           console.error(err);
+          this.toasterService.error('Failed to create item.', 'Error');
         },
       })
     }


### PR DESCRIPTION
## Summary
- show toastr messages for CRUD success & error
- keep loader interceptor only

## Testing
- `npm test` *(fails: ng not found)*